### PR TITLE
fix passing server port back into callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,11 @@ Nicercast.prototype.setInputStream = function (inputStream) {
 }
 
 Nicercast.prototype.listen = function (port, hostname, backlog, callback) {
-  this._server.listen.apply(this._server, arguments)
+  this._server.listen(port, hostname, backlog, () => {
+    // If a port of 0 is provided, the server will pick an appropriate port.
+    // ensure we invoke our callback with whatever port is running
+    callback(this._server.address().port)
+  })
 }
 
 Nicercast.prototype.close = function (callback) {
@@ -142,7 +146,7 @@ Nicercast.prototype.address = function () {
 }
 
 function start (port, callback) {
-  this.listen(port, callback)
+  this.listen(port, undefined, undefined, callback)
 }
 
 function stop () {


### PR DESCRIPTION
Hi @LinusU!

I had a play with your cleanup of nicercast, great job!

I had a similar issue to @yoiang where I couldn't use this as a drop in replacement with airsonos. I found it was simply that the port was not being provided correctly to the listen callback - here's the fix.

BTW I'm trying to gather patched versions of airsonos, nicercast, and nodetunes on my remote (jabooth) as I get the sense looking over the activity on these repos over the last 12 months that @stephen is a little bandwidth constrained to play with all this stuff at the mo! I'm hoping that might be a proving ground for this stuff for @stephen to look over down the line, hope that's OK! 👍 